### PR TITLE
 Corrected bug in evaluate_rule_dense_only

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: xrf
 Title: eXtreme RuleFit
-Version: 0.1.0
+Version: 0.1.1
 Authors@R: person("Karl", "Holub", email = "karljholub@gmail.com", role = c("aut", "cre"))
 Description: An implementation of the RuleFit algorithm as described in Friedman & Popescu (2008; 
     <doi:10.1214/07-AOAS148>). eXtreme Gradient Boosting ('XGBoost') is used 

--- a/R/xrf.R
+++ b/R/xrf.R
@@ -274,7 +274,7 @@ evaluate_rules_dense_only <- function(rules, data) {
       # yes, this is fast
       rule_evaluation = eval(parse(text=paste0(
         paste0('`', .data$feature, '`'),
-        ifelse(.data$less_than, '<', '>='),
+        ifelse(.data$less_than, ' < ', ' >= '),
         .data$split,
         collapse = ' & '
       )), 


### PR DESCRIPTION
Was a bug where you would generate expressions like:
  v4>=2 & v10<-3
which R would interpret as
  (v4>=2 & V10) <- 3
which generates an error.
I added ' ' before and after '<' and '>=' to get
  v4 > 2 & v10 < -3
