### PR TITLE
Fixes for #9

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -3,3 +3,4 @@
 ^\.Rproj\.user$
 ^CONTRIBUTING\.md$
 ^cran-comments\.md$
+^docs$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,7 +15,7 @@ Depends: R (>= 3.1.0)
 License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 6.1.1
+RoxygenNote: 7.0.1.9000
 Imports: 
     Matrix,
     glmnet,

--- a/R/xrf.R
+++ b/R/xrf.R
@@ -487,9 +487,13 @@ model.matrix.xrf <- function(object, data, sparse = TRUE, ...) {
   # TODO: handle missing factor levels more elegantly (both for rule evaluation & glmnet)
   # TODO: when rules have a zero coefficient and we just want to predict, we don't need to evaluate them
   stopifnot(is.data.frame(data))
+
+  trms <- terms(object$base_formula)
+  trms <- delete.response(trms)
+
   design_matrix_method <- if (sparse) sparse.model.matrix else model.matrix
 
-  raw_design_matrix <- design_matrix_method(object$base_formula, data)
+  raw_design_matrix <- design_matrix_method(trms, data)
   rules_features <- if (sparse) evaluate_rules(object$rules, raw_design_matrix) else evaluate_rules_dense_only(object$rules, raw_design_matrix)
   full_data <- cbind(data, rules_features,
                      stringsAsFactors = FALSE)

--- a/R/xrf.R
+++ b/R/xrf.R
@@ -333,7 +333,7 @@ dedupe_train_rules <- function(evaluated_rules) {
 #'
 #' @export
 xrf <- function(object, ...) {
-  UseMethod('xrf')
+  UseMethod('xrf', object)
 }
 
 #' Fit an eXtreme RuleFit model

--- a/R/xrf.R
+++ b/R/xrf.R
@@ -7,9 +7,9 @@ condition_xgb_control <- function(family, xgb_control, data, response_var) {
   if (!(response_var %in% colnames(data))) {
     stop(paste0('Response variable "', response_var, '" not present in supplied data'))
   }
-  
+
   data_mutated <- data
-  
+
   if (family == 'multinomial' && is.null(xgb_control$num_class)) {
     n_classes <- n_distinct(data[[response_var]])
     warning(paste0('Detected ', as.character(n_classes), ' classes to set num_class xgb_control parameter'))
@@ -17,7 +17,7 @@ condition_xgb_control <- function(family, xgb_control, data, response_var) {
   }
 
   # xgboost expects multinomial labels to be 0:num_class
-  if (family == 'multinomial' && 
+  if (family == 'multinomial' &&
       (is.factor(data[[response_var]]) || is.character(data[[response_var]]))) {
     integer_response <- as.integer(as.factor(data[[response_var]]))
     data_mutated[[response_var]] <- integer_response - min(integer_response)
@@ -27,7 +27,7 @@ condition_xgb_control <- function(family, xgb_control, data, response_var) {
     integer_response <- as.integer(as.factor(data[[response_var]]))
     data_mutated[[response_var]] <- integer_response - min(integer_response)
   }
-  
+
   list(xgb_control = xgb_control,
        data = data_mutated)
 }
@@ -38,48 +38,48 @@ xrf_preconditions <- function(family, xgb_control, glm_control,
   if (!(family %in% supported_families)) {
     stop(paste0('Family "', family, '" is not currently supported. Supported families are: ', paste0(supported_families, collapse = ', ')))
   }
-  
+
   if (!('nrounds' %in% names(xgb_control))) {
     stop('Must supply an "nrounds" list element to the xgb_control argument')
   }
-  
+
   if ('objective' %in% names(xgb_control)) {
     stop('User may not supply an "objective" list element to the xgb_control argument')
   }
-  
+
   if (!(response_var %in% colnames(data))) {
     stop(paste0('Response variable "', response_var, '" not present in supplied data'))
   }
-  
+
   if (any(is.na(data[[response_var]]))) {
     stop('Response variable contains missing values which is not allowed')
   }
-  
+
   if (n_distinct(data[[response_var]]) <= 1) {
     # TODO cv.glmnet will still warn/fail when there is a very small number of observations per class for logistic regression
     stop('Response variable shows no variation, model cannot be fit')
   }
-  
-  if (family == 'multinomial' && 
+
+  if (family == 'multinomial' &&
       (is.null(xgb_control$num_class) || n_distinct(data[[response_var]]) != xgb_control$num_class)) {
     stop('Must supply a num_class list element in xgb_control when using multinomial objective')
   }
-  
+
   if (length(intersect(c('type.measure', 'nfolds', 'foldid'), names(glm_control))) < 2) {
     stop('Must supply "type.measure" and ("nfolds" or "foldid") as glm_control parameters')
   }
-  
+
   allowed_tree_ensemble_classes <- c('xgb.Booster')
   if (!is.null(prefit_xgb) && length(intersect(allowed_tree_ensemble_classes, class(prefit_xgb))) == 0) {
     stop('Prefit tree ensemble must be of class {', paste0(allowed_tree_ensemble_classes, collapse = ','), "}")
   }
-  
+
   features_with_commas <- grepl(',', colnames(data), fixed = TRUE)
   if (any(features_with_commas)) {
     feature_names <- colnames(data)[features_with_commas]
     stop(paste0('The following column names contain illegal characters: ', paste0("'", features_with_commas, "'", collapse = ',')))
   }
-  
+
 }
 
 ## the choice of ensemble loss is currently hidden from the api to protect implementation details
@@ -94,7 +94,7 @@ get_xgboost_objective <- function(family) {
   else if (family == 'multinomial') {
     return('multi:softmax')
   }
-  
+
   stop(paste0('Unrecognized family ', family, ' which should have failed fast in preconditions'))
 }
 
@@ -132,14 +132,14 @@ rule_traverse <- function(row, tree) {
     stopifnot(nrow(left_child) == 1) # this can be trusted from xgboost, but fail if that changes
     right_child <- tree[tree$ID == row$No,]
     stopifnot(nrow(right_child) == 1)
-    
+
     # recursion will bubble up the conjunctive rule to this split
     left_rules <- rule_traverse(left_child, tree)
     right_rules <- rule_traverse(right_child, tree)
-    
+
     left_rules_augmented <- augment_rules(row, unique(left_rules$rule_id), less_than = TRUE)
     right_rules_augmented <- augment_rules(row, unique(right_rules$rule_id), less_than = FALSE)
-    
+
     return(rbind(left_rules_augmented, right_rules_augmented, left_rules, right_rules,
                  stringsAsFactors = FALSE))
   }
@@ -152,11 +152,11 @@ extract_xgb_rules <- function(m) {
   rules <- xgb.model.dt.tree(model = m) %>%
     group_by(.data$Tree) %>%
     arrange(.data$Node) %>% # put the root at the top of each tree group
-    do(harvested_rules = rule_traverse(.data[1, ], .data) %>% 
+    do(harvested_rules = rule_traverse(.data[1, ], .data) %>%
          filter(!is.na(.data$feature))) %>%
     pull(.data$harvested_rules) %>%
     bind_rows()
-  
+
   rules
 }
 
@@ -166,20 +166,20 @@ extract_xgb_rules <- function(m) {
 ##################################################
 
 build_feature_metadata <- function(data) {
-  all_features <- data.frame(feature_name = colnames(data), 
+  all_features <- data.frame(feature_name = colnames(data),
                              stringsAsFactors = FALSE)
-  
+
   feature_metadata <- all_features %>%
     mutate(
       is_continuous = sapply(.data$feature_name, function(fname){ is.numeric(data[[fname]]) })
     )
-  
-  xlev <- data %>% 
+
+  xlev <- data %>%
     select_if(function(x) { !is.numeric(x) }) %>%
     lapply(function(x) {
       if(is.factor(x)) levels(x) else as.character(unique(x))
     })
-  
+
   list(
     xlev = xlev,
     feature_metadata = feature_metadata
@@ -190,12 +190,12 @@ has_matching_level <- function(feature_name, level_remainder, xlev) {
   for (ix in seq_along(feature_name)) {
     fn <- feature_name[ix]
     lr <- level_remainder[ix]
-    
+
     if (lr %in% xlev[[fn]]) {
       return(TRUE)
     }
   }
-  
+
   return(FALSE)
 }
 
@@ -205,7 +205,7 @@ correct_xgb_sparse_categoricals <- function(rules, feature_metadata, xlev,
   if (nrow(rules) == 0) {
     return(rules)
   }
-  
+
   for (row_ix in 1:nrow(rules)) {
     feature_level <- rules[row_ix, 'feature']
     classified_features <- feature_metadata %>%
@@ -213,11 +213,11 @@ correct_xgb_sparse_categoricals <- function(rules, feature_metadata, xlev,
         level_remainder = sapply(.data$feature_name, function(fn){ lstrip(feature_level, fn) }),
         may_be_rule_feature = sapply(.data$feature_name, function(fn) { !startsWith(feature_level, fn) })
       )
-    
+
     feature_level_matches <- classified_features %>%
       filter(!.data$may_be_rule_feature) %>%
       filter(.data$level_remainder == '' | has_matching_level(.data$feature_name, .data$level_remainder, xlev))
-    
+
     if (nrow(feature_level_matches) > 1) {
       # this means that several feaures and their levels may be concatenated to produce the same column name
       # e.g. feature "ora" with level "nge" and another feature "oran" with level "ge". or even a continuous with name "orange"
@@ -227,7 +227,7 @@ correct_xgb_sparse_categoricals <- function(rules, feature_metadata, xlev,
       # the feature couldn't be found. this is usually because a transformation was applied via the formula
       stop(paste0('In attempting to parse sparse design matrix columns, no feature/level matches found for: "', feature_level, '". This is often caused by supplying a transformation in the input formula. User may either transform source data and use main effects only formula or set argument sparse=FALSE.'))
     }
-    
+
     if (!feature_level_matches$is_continuous) {
       # xgb always makes the split value negative, so that "Missing" (= 0 one-hot) really maps to "Yes" (the left, less than split)
       # and the right, greater than split (1 one-hot) maps to "No"
@@ -238,7 +238,7 @@ correct_xgb_sparse_categoricals <- function(rules, feature_metadata, xlev,
       rules[row_ix, 'split'] <- categorical_split_value
     }
   }
-  
+
   rules
 }
 
@@ -254,23 +254,23 @@ evaluate_rules <- function(rules, data) {
         split <- .data[split_ix, ]
         feature_ix <- which(split$feature == colnames(data))
         if (length(feature_ix) == 0) {
-          stop(paste0('Feature "', split$feature, 
+          stop(paste0('Feature "', split$feature,
                          '" from ruleset is not present in the input data to be evaluated'))
         }
         else if (length(feature_ix) > 1) {
-          stop(paste0('Unexpectedly found two columns with the same name in input data (user must resolve): ', 
+          stop(paste0('Unexpectedly found two columns with the same name in input data (user must resolve): ',
                       split$feature))
         }
         split_comparison <- data[, feature_ix] < split$split
         return(split_comparison == split$less_than)
-      }) %>% 
-      apply(1, all) %>% 
+      }) %>%
+      apply(1, all) %>%
       as.integer() %>%
       data.frame()
     )
   rule_features <- bind_cols(per_rule_evaluation$rule_evaluation)
   colnames(rule_features) <- per_rule_evaluation$rule_id
-  
+
   rule_features
 }
 
@@ -286,14 +286,14 @@ evaluate_rules_dense_only <- function(rules, data) {
         ifelse(.data$less_than, ' < ', ' >= '),
         .data$split,
         collapse = ' & '
-      )), 
+      )),
       data_df) %>%
         as.integer() %>%
         data.frame()
     )
   rule_features <- bind_cols(per_rule_evaluation$rule_evaluation)
   colnames(rule_features) <- per_rule_evaluation$rule_id
-  
+
   rule_features
 }
 
@@ -307,7 +307,7 @@ remove_no_variance_rules <- function(evaluated_rules) {
   keep_columns <- sapply(evaluated_rules, function(feature) {
     length(unique(feature)) > 1
   })
-  
+
   return(colnames(evaluated_rules)[keep_columns])
 }
 
@@ -322,27 +322,27 @@ dedupe_train_rules <- function(evaluated_rules) {
 #'
 #' S3 method for building an "eXtreme RuleFit" model.
 #' See \code{\link{xrf.formula}} for preferred entry point
-#' 
+#'
 #' @param object an object describing the model to be fit
 #' @param ... additional arguments
-#' 
-#' @examples 
-#' m <- xrf(Petal.Length ~ ., iris, 
+#'
+#' @examples
+#' m <- xrf(Petal.Length ~ ., iris,
 #'          xgb_control = list(nrounds = 20, max_depth = 2),
 #'          family = 'gaussian')
-#'          
+#'
 #' @export
 xrf <- function(object, ...) {
-  UseMethod('xrf', object)
+  UseMethod('xrf')
 }
 
 #' Fit an eXtreme RuleFit model
-#' 
+#'
 #' See Friedman & Popescu (2008) for a description of the general RuleFit algorithm.
-#' This method uses XGBoost to fit a tree ensemble, extracts a ruleset as the conjunction of tree 
+#' This method uses XGBoost to fit a tree ensemble, extracts a ruleset as the conjunction of tree
 #' traversals, and fits a sparse linear model to the resulting feature set
 #' (including the original feature set) using glmnet.
-#' 
+#'
 #' @param object a formula prescribing features to use in the model. transformation of the response variable is not supported. when using transformations on the input features (not suggested in general) it is suggested to set sparse=F
 #' @param data a data frame with columns corresponding to the formula
 #' @param family the family of the fitted model. one of 'gaussian', 'binomial', 'multinomial'
@@ -351,8 +351,8 @@ xrf <- function(object, ...) {
 #' @param sparse whether a sparse design matrix should be used
 #' @param prefit_xgb an xgboost model (of class xgb.Booster) to be used instead of the model that \code{xrf} would normally fit
 #' @param deoverlap if true, the tree derived rules are deoverlapped, in that the deoverlapped rule set contains no overlapped rules
-#' @param ... ignored arguments 
-#' 
+#' @param ... ignored arguments
+#'
 #' @importFrom xgboost xgboost
 #' @importFrom xgboost xgb.model.dt.tree
 #' @import dplyr
@@ -365,13 +365,13 @@ xrf <- function(object, ...) {
 #' @importFrom stats predict
 #' @importFrom stats terms
 #' @importFrom stats update
-#' 
-#' @references 
-#' Friedman, J. H., & Popescu, B. E. (2008). Predictive learning via rule 
+#'
+#' @references
+#' Friedman, J. H., & Popescu, B. E. (2008). Predictive learning via rule
 #' ensembles. \emph{The Annals of Applied Statistics, 2}(3), 916-954.
-#' 
-#' @examples 
-#' m <- xrf(Petal.Length ~ ., iris, 
+#'
+#' @examples
+#' m <- xrf(Petal.Length ~ ., iris,
 #'          xgb_control = list(nrounds = 20, max_depth = 2),
 #'          family = 'gaussian')
 #'
@@ -386,15 +386,15 @@ xrf.formula <- function(object, data, family,
                         ...) {
   expanded_formula <- expand_formula(object, data)
   response_var <- get_response(expanded_formula)
-  
+
   xgboost_conditioned <- condition_xgb_control(family, xgb_control, data, response_var)
   xgb_control <- xgboost_conditioned$xgb_control
   data <- xgboost_conditioned$data
   xrf_preconditions(family, xgb_control, glm_control, data, response_var, prefit_xgb)
-  
-  model_matrix_method <- if (sparse) sparse.model.matrix else model.matrix 
+
+  model_matrix_method <- if (sparse) sparse.model.matrix else model.matrix
   design_matrix <- model_matrix_method(expanded_formula, data)
-  
+
   if (is.null(prefit_xgb)) {
     m_xgb <- xgboost(data = design_matrix,
                      label = data[[response_var]],
@@ -413,40 +413,40 @@ xrf.formula <- function(object, data, family,
       # but that potentially dilutes the power of this method. for now, it's on the user to rectify this issue
     }
   }
-  
+
   if (sparse) {
     feature_metadata <- build_feature_metadata(data)
     rules <- correct_xgb_sparse_categoricals(rules, feature_metadata$feature_metadata, feature_metadata$xlev)
   }
-  
+
   if (deoverlap){
     rules <- xrf_deoverlap_rules(rules) %>%
       select(.data$rule_id, .data$feature, .data$split, .data$less_than)
   }
 
   rule_features <- if (sparse) evaluate_rules(rules, design_matrix) else evaluate_rules_dense_only(rules, design_matrix)
-  
+
   varying_rules <- remove_no_variance_rules(rule_features)
   rule_features <- rule_features[, varying_rules]
   rules <- rules %>%
     filter(.data$rule_id %in% varying_rules)
-  
+
   non_duplicate_rules <- dedupe_train_rules(rule_features)
   rule_features <- rule_features[, non_duplicate_rules]
   rules <- rules %>%
     filter(.data$rule_id %in% non_duplicate_rules)
-    
+
   overlapped_feature_names <- intersect(colnames(rule_features), colnames(data))
   if (length(overlapped_feature_names) > 0) {
-    warning(paste0('Found the following overlapped raw feature & rule names (the rule features will be dropped): ', 
+    warning(paste0('Found the following overlapped raw feature & rule names (the rule features will be dropped): ',
                    paste(overlapped_feature_names, collapse = ',')))
     rule_features <- rule_features[, !(colnames(rule_features) %in% overlapped_feature_names)]
   }
-  
+
   # todo we already have a design matrix, so re-generating it with glmnot is a bit wasteful
-  full_data <- cbind(data, rule_features, 
+  full_data <- cbind(data, rule_features,
                      stringsAsFactors = FALSE)
-  
+
   # todo glmnet is a bottleneck on data size - it may be interesting to fit the glm to much larger data, e.g. with spark or biglasso
   full_formula <- add_predictors(expanded_formula, colnames(rule_features))
 
@@ -475,9 +475,9 @@ xrf.formula <- function(object, data, family,
 #' @param ... ignored arguments
 #'
 #' @importFrom Matrix sparse.model.matrix
-#' 
-#' @examples 
-#' m <- xrf(Petal.Length ~ ., iris, 
+#'
+#' @examples
+#' m <- xrf(Petal.Length ~ ., iris,
 #'          xgb_control = list(nrounds = 20, max_depth = 2),
 #'          family = 'gaussian')
 #' design <- model.matrix(m, iris, sparse = FALSE)
@@ -488,10 +488,10 @@ model.matrix.xrf <- function(object, data, sparse = TRUE, ...) {
   # TODO: when rules have a zero coefficient and we just want to predict, we don't need to evaluate them
   stopifnot(is.data.frame(data))
   design_matrix_method <- if (sparse) sparse.model.matrix else model.matrix
-  
+
   raw_design_matrix <- design_matrix_method(object$base_formula, data)
   rules_features <- if (sparse) evaluate_rules(object$rules, raw_design_matrix) else evaluate_rules_dense_only(object$rules, raw_design_matrix)
-  full_data <- cbind(data, rules_features, 
+  full_data <- cbind(data, rules_features,
                      stringsAsFactors = FALSE)
 
   full_data
@@ -507,11 +507,11 @@ model.matrix.xrf <- function(object, data, sparse = TRUE, ...) {
 #' @param ... ignored arguments
 #'
 #' @examples
-#' m <- xrf(Petal.Length ~ ., iris, 
+#' m <- xrf(Petal.Length ~ ., iris,
 #'          xgb_control = list(nrounds = 20, max_depth = 2),
 #'          family = 'gaussian')
 #' predictions <- predict(m, iris)
-#' 
+#'
 #' @export
 predict.xrf <- function(object, newdata,
                         sparse = TRUE,
@@ -521,7 +521,7 @@ predict.xrf <- function(object, newdata,
   stopifnot(is.data.frame(newdata))
   full_data <- model.matrix(object, newdata, sparse)
 
-  predict(object$glm, newdata = full_data, 
+  predict(object$glm, newdata = full_data,
           sparse = sparse, lambda = lambda, type = type)
 }
 
@@ -544,9 +544,9 @@ synthesize_conjunctions <- function(rules) {
 #' @param object an object of class "xrf"
 #' @param lambda the lasso penalty parameter to be applied as in 'glmnet'
 #' @param ... ignored arguments
-#' 
+#'
 #' @examples
-#' m <- xrf(Petal.Length ~ ., iris, 
+#' m <- xrf(Petal.Length ~ ., iris,
 #'          xgb_control = list(nrounds = 20, max_depth = 2),
 #'          family = 'gaussian')
 #' linear_model_coefficients <- coef(m, lambda = 'lambda.1se')
@@ -569,15 +569,15 @@ coef.xrf <- function(object, lambda = 'lambda.min', ...) {
 }
 
 #' Summarize an eXtreme RuleFit model
-#' 
+#'
 #' @param object an object of class "xrf"
 #' @param ... ignored arguments
-#' 
+#'
 #' @import dplyr
 #' @importFrom methods show
-#' 
+#'
 #' @examples
-#' m <- xrf(Petal.Length ~ ., iris, 
+#' m <- xrf(Petal.Length ~ ., iris,
 #'          xgb_control = list(nrounds = 20, max_depth = 2),
 #'          family = 'gaussian')
 #' summary(m)
@@ -597,9 +597,9 @@ summary.xrf <- function(object, ...) {
 #'
 #' @param x an object of class "xrf"
 #' @param ... ignored arguments
-#' 
-#' @examples 
-#' m <- xrf(Petal.Length ~ ., iris, 
+#'
+#' @examples
+#' m <- xrf(Petal.Length ~ ., iris,
 #'          xgb_control = list(nrounds = 20, max_depth = 2),
 #'          family = 'gaussian')
 #' print(m)
@@ -609,4 +609,4 @@ print.xrf <- function(x, ...) {
   cat(paste0('An eXtreme RuleFit model of ', n_distinct(x$rules$rule_id), ' rules.'))
   cat(paste0('\n\nFormula:\n\n'))
   cat(paste(x$base_formula[2], x$base_formula[3],sep=' ~ '))
-}  
+}

--- a/man/coef.xrf.Rd
+++ b/man/coef.xrf.Rd
@@ -17,7 +17,7 @@
 Produce rules & coefficients for the RuleFit model
 }
 \examples{
-m <- xrf(Petal.Length ~ ., iris, 
+m <- xrf(Petal.Length ~ ., iris,
          xgb_control = list(nrounds = 20, max_depth = 2),
          family = 'gaussian')
 linear_model_coefficients <- coef(m, lambda = 'lambda.1se')

--- a/man/model.matrix.xrf.Rd
+++ b/man/model.matrix.xrf.Rd
@@ -19,7 +19,7 @@
 Generate the design matrix from an eXtreme RuleFit model
 }
 \examples{
-m <- xrf(Petal.Length ~ ., iris, 
+m <- xrf(Petal.Length ~ ., iris,
          xgb_control = list(nrounds = 20, max_depth = 2),
          family = 'gaussian')
 design <- model.matrix(m, iris, sparse = FALSE)

--- a/man/predict.xrf.Rd
+++ b/man/predict.xrf.Rd
@@ -4,8 +4,14 @@
 \alias{predict.xrf}
 \title{Draw predictions from a RuleFit xrf model}
 \usage{
-\method{predict}{xrf}(object, newdata, sparse = TRUE,
-  lambda = "lambda.min", type = "response", ...)
+\method{predict}{xrf}(
+  object,
+  newdata,
+  sparse = TRUE,
+  lambda = "lambda.min",
+  type = "response",
+  ...
+)
 }
 \arguments{
 \item{object}{an object of class "xrf"}
@@ -24,7 +30,7 @@
 Draw predictions from a RuleFit xrf model
 }
 \examples{
-m <- xrf(Petal.Length ~ ., iris, 
+m <- xrf(Petal.Length ~ ., iris,
          xgb_control = list(nrounds = 20, max_depth = 2),
          family = 'gaussian')
 predictions <- predict(m, iris)

--- a/man/print.xrf.Rd
+++ b/man/print.xrf.Rd
@@ -15,7 +15,7 @@
 Print an eXtreme RuleFit model
 }
 \examples{
-m <- xrf(Petal.Length ~ ., iris, 
+m <- xrf(Petal.Length ~ ., iris,
          xgb_control = list(nrounds = 20, max_depth = 2),
          family = 'gaussian')
 print(m)

--- a/man/summary.xrf.Rd
+++ b/man/summary.xrf.Rd
@@ -15,7 +15,7 @@
 Summarize an eXtreme RuleFit model
 }
 \examples{
-m <- xrf(Petal.Length ~ ., iris, 
+m <- xrf(Petal.Length ~ ., iris,
          xgb_control = list(nrounds = 20, max_depth = 2),
          family = 'gaussian')
 summary(m)

--- a/man/xrf.Rd
+++ b/man/xrf.Rd
@@ -16,8 +16,8 @@ S3 method for building an "eXtreme RuleFit" model.
 See \code{\link{xrf.formula}} for preferred entry point
 }
 \examples{
-m <- xrf(Petal.Length ~ ., iris, 
+m <- xrf(Petal.Length ~ ., iris,
          xgb_control = list(nrounds = 20, max_depth = 2),
          family = 'gaussian')
-         
+
 }

--- a/man/xrf.formula.Rd
+++ b/man/xrf.formula.Rd
@@ -4,10 +4,17 @@
 \alias{xrf.formula}
 \title{Fit an eXtreme RuleFit model}
 \usage{
-\method{xrf}{formula}(object, data, family, xgb_control = list(nrounds =
-  100, max_depth = 3), glm_control = list(type.measure = "deviance",
-  nfolds = 5), sparse = TRUE, prefit_xgb = NULL, deoverlap = FALSE,
-  ...)
+\method{xrf}{formula}(
+  object,
+  data,
+  family,
+  xgb_control = list(nrounds = 100, max_depth = 3),
+  glm_control = list(type.measure = "deviance", nfolds = 5),
+  sparse = TRUE,
+  prefit_xgb = NULL,
+  deoverlap = FALSE,
+  ...
+)
 }
 \arguments{
 \item{object}{a formula prescribing features to use in the model. transformation of the response variable is not supported. when using transformations on the input features (not suggested in general) it is suggested to set sparse=F}
@@ -30,17 +37,17 @@
 }
 \description{
 See Friedman & Popescu (2008) for a description of the general RuleFit algorithm.
-This method uses XGBoost to fit a tree ensemble, extracts a ruleset as the conjunction of tree 
+This method uses XGBoost to fit a tree ensemble, extracts a ruleset as the conjunction of tree
 traversals, and fits a sparse linear model to the resulting feature set
 (including the original feature set) using glmnet.
 }
 \examples{
-m <- xrf(Petal.Length ~ ., iris, 
+m <- xrf(Petal.Length ~ ., iris,
          xgb_control = list(nrounds = 20, max_depth = 2),
          family = 'gaussian')
 
 }
 \references{
-Friedman, J. H., & Popescu, B. E. (2008). Predictive learning via rule 
+Friedman, J. H., & Popescu, B. E. (2008). Predictive learning via rule
 ensembles. \emph{The Annals of Applied Statistics, 2}(3), 916-954.
 }

--- a/tests/testthat/test_model.R
+++ b/tests/testthat/test_model.R
@@ -94,3 +94,15 @@ test_that('model predicts without outcome column', {
   expect_equal(predict(mod_nsp, mtcars[1:5, ],   sparse = FALSE)[, 1],
                predict(mod_nsp, mtcars[1:5, -1], sparse = FALSE)[, 1])
 })
+
+test_that('call scrubbed', {
+  mod_nsp <- xrf(mpg ~ ., data = mtcars[-(1:5), ],
+                 xgb_control = list(nrounds = 5, max_depth = 2),
+                 family = "gaussian", sparse = FALSE)
+
+  # in previous version:
+  # > object.size(mod_nsp$glm$model$call)
+  # 211544 bytes
+  expect_true(object.size(mod_nsp$glm$model$call) < 211544)
+})
+

--- a/tests/testthat/test_model.R
+++ b/tests/testthat/test_model.R
@@ -13,20 +13,20 @@ dataset <- mtcars %>%
 test_expected_fields <- function(model, depth, trees) {
   max_splits <- (2 ^ (depth + 1) - 2) * trees # number of edges in a binary tree for each tree = number of nodes - 1
   max_rules <- 2 ^ depth * trees # number of root -> leaf traversals in a binary tree for each tree
-  
+
   expected_max_coef <- 1 + # intercept
     1 + # continuous mpg
     1 + # continuous displacement
     length(unique(dataset$cyl)) - 1 +
     max_rules
-  
+
   expect_setequal(c('glm', 'xgb', 'base_formula', 'rule_augmented_formula', 'rules'), names(model))
   expect_s3_class(model$glm, 'glmnot')
   expect_s3_class(model$xgb, 'xgb.Booster')
   expect_s3_class(model$base_formula, 'formula')
   expect_s3_class(model$rule_augmented_formula, 'formula')
   expect_s3_class(model$rules, 'data.frame')
-  
+
   expect_lte(nrow(model$rules), max_splits)
   expect_lte(n_distinct(model$rules$rule_id), max_rules)
   expect_lte(nrow(coef(model, lambda = 'lambda.min')), expected_max_coef)
@@ -37,7 +37,7 @@ test_that('model from dense design matrix has expected fields', {
   trees <- 3
   m_xrf <- xrf(am ~ mpg + as.factor(cyl) + disp, dataset, family = 'binomial',
                xgb_control = list(nrounds = trees, max_depth = depth), sparse = FALSE)
-  
+
   test_expected_fields(m_xrf, depth, trees)
 })
 
@@ -46,36 +46,51 @@ test_that('model from sparse design matrix has expected fields', {
   trees <- 3
   m_xrf <- xrf(am ~ mpg + cyl + disp, dataset, family = 'binomial',
                xgb_control = list(nrounds = 3, max_depth = 2))
-  
+
   test_expected_fields(m_xrf, depth, trees)
 })
 
 test_that('model predicts binary outcome', {
   m_xrf <- xrf(am ~ mpg + cyl + disp + hp + drat + wt + qsec, dataset, family = 'binomial',
-               xgb_control = list(nrounds = 3, max_depth = 2), 
+               xgb_control = list(nrounds = 3, max_depth = 2),
                glm_control = list(type.measure='deviance', nfolds=10))
   preds_response_dense <- predict(m_xrf, dataset, type = 'response', sparse = FALSE)
   preds_response_sparse <- predict(m_xrf, dataset, type = 'response', sparse = TRUE)
-  
+
   preds_link <- predict(m_xrf, dataset, type = 'link')
-  
+
   expect_equal(preds_response_dense, preds_response_sparse)
   expect(all(preds_response_dense < 1 & preds_response_dense > 0), 'Binomial predicted outcome does not represent a valid posterior')
   expect(all(preds_response_sparse< 1 & preds_response_sparse > 0), 'Binomial predicted outcome does not represent a valid posterior')
-  # since we are using deviance on the LASSO fit, the model should be calibrated 
+  # since we are using deviance on the LASSO fit, the model should be calibrated
   expect_equal(mean(preds_response_dense), mean(dataset$am == '1'))
-  
+
   expect(any(preds_link < 0 | preds_link > 1), 'Link predictions appear to be probabilities')
 })
 
 test_that('model predicts continuous outcome', {
   m_xrf <- xrf(mpg ~ ., dataset, family = 'gaussian',
-               xgb_control = list(nrounds = 3, max_depth = 2), 
+               xgb_control = list(nrounds = 3, max_depth = 2),
                glm_control = list(type.measure='deviance', nfolds=10))
-  
+
   preds <- predict(m_xrf, dataset, type = 'response', sparse = FALSE)
-  
+
   expect_equal(mean(preds), mean(dataset$mpg))
   mae <- mean(abs(preds - dataset$mpg))
   expect_lt(mae, 5) # since this should be highly parameterized / overfit
+})
+
+
+test_that('model predicts without outcome column', {
+ # issue #9
+  mod <- xrf(mpg ~ ., data = mtcars[-(1:5), ],
+             xgb_control = list(nrounds = 5, max_depth = 2),
+             family = "gaussian")
+  expect_equal(predict(mod, mtcars[1:5, ])[,1], predict(mod, mtcars[1:5, -1])[,1])
+
+  mod_nsp <- xrf(mpg ~ ., data = mtcars[-(1:5), ],
+                 xgb_control = list(nrounds = 5, max_depth = 2),
+                 family = "gaussian", sparse = FALSE)
+  expect_equal(predict(mod_nsp, mtcars[1:5, ],   sparse = FALSE)[, 1],
+               predict(mod_nsp, mtcars[1:5, -1], sparse = FALSE)[, 1])
 })

--- a/xrf.Rproj
+++ b/xrf.Rproj
@@ -5,7 +5,12 @@ SaveWorkspace: No
 AlwaysSaveHistory: Default
 
 EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
 Encoding: UTF-8
+
+RnwWeave: knitr
+LaTeX: pdfLaTeX
 
 AutoAppendNewline: Yes
 StripTrailingWhitespace: Yes


### PR DESCRIPTION
> Currently, if the response column is missing from the `predict`ed dataframe, an error is thrown. This shouldn't throw an error, as the information isn't needed for prediction.

This is mostly because `predict.xrf` doesn't remove the outcome (see, for example, `predict.lm()`). This PR adds

```r
  trms <- terms(object$base_formula)
  trms <- delete.response(trms)
```

and feed `trms` to the versions of `model.matrix`. 

I also noticed that the `glmnot` model object embedded the training set data and the contents of `glmnet()` into the call. Now it gets:


```r
> mod_nsp$glm$model$call
glmnet(x = x, y = y, type.measure = "deviance", nfolds = 5, family = "gaussian", 
    alpha = 1)
``` 

instead of 

``` r
library(xrf)

mod_nsp <- xrf(mpg ~ ., data = mtcars[-(1:5), ],
               xgb_control = list(nrounds = 5, max_depth = 2),
               family = "gaussian", sparse = FALSE)

mod_nsp$glm$model$call
#> (function (x, y, weights = NULL, offset = NULL, lambda = NULL, 
#>     type.measure = c("default", "mse", "deviance", "class", "auc", 
#>         "mae", "C"), nfolds = 10, foldid = NULL, alignment = c("lambda", 
#>         "fraction"), grouped = TRUE, keep = FALSE, parallel = FALSE, 
#>     gamma = c(0, 0.25, 0.5, 0.75, 1), relax = FALSE, trace.it = 0, 
#>     ...) 
#> {
#>     type.measure = match.arg(type.measure)
#>     alignment = match.arg(alignment)
#>     if (!is.null(lambda) && length(lambda) < 2) 
#>         stop("Need more than one value of lambda for cv.glmnet")
#>     if (!is.null(lambda) && alignment == "fraction") {
#>         warning("fraction of path alignment not available if lambda given as argument; switched to alignment=`lambda`")
#>         alignment = "lambda"
#>     }
#>     N = nrow(x)
#>     if (is.null(weights)) 
#>         weights = rep(1, N)
#>     else weights = as.double(weights)
#>     y = drop(y)
#>     cv.call = glmnet.call = match.call(expand.dots = TRUE)
#>     which = match(c("type.measure", "nfolds", "foldid", "grouped", 
#>         "keep"), names(glmnet.call), FALSE)
#>     if (any(which)) 
#>         glmnet.call = glmnet.call[-which]
#>     glmnet.call[[1]] = as.name("glmnet")
#>     if (glmnet.control()$itrace) 
#>         trace.it = 1
#>     else {
#>         if (trace.it) {
#>             glmnet.control(itrace = 1)
#>             on.exit(glmnet.control(itrace = 0))
#>         }
#>     }
#>     if (is.null(foldid)) 
#>         foldid = sample(rep(seq(nfolds), length = N))
#>     else nfolds = max(foldid)
#>     if (nfolds < 3) 
#>         stop("nfolds must be bigger than 3; nfolds=10 recommended")
#>     if (relax) 
#>         cv.relaxed.raw(x, y, weights, offset, lambda, type.measure, 
#>             nfolds, foldid, alignment, grouped, keep, parallel, 
#>             trace.it, glmnet.call, cv.call, gamma, ...)
#>     else cv.glmnet.raw(x, y, weights, offset, lambda, type.measure, 
#>         nfolds, foldid, alignment, grouped, keep, parallel, trace.it, 
#>         glmnet.call, cv.call, ...)
#> })(x = c(6, 8, 4, 4, 6, 6, 8, 8, 8, 8, 8, 8, 4, 4, 4, 4, 8, 8, 
#> 8, 8, 4, 4, 4, 8, 6, 8, 4, 225, 360, 146.7, 140.8, 167.6, 167.6, 
#> 275.8, 275.8, 275.8, 472, 460, 440, 78.7, 75.7, 71.1, 120.1, 
#> 318, 304, 350, 400, 79, 120.3, 95.1, 351, 145, 301, 121, 105, 
#> 245, 62, 95, 123, 123, 180, 180, 180, 205, 215, 230, 66, 52, 
#> 65, 97, 150, 150, 245, 175, 66, 91, 113, 264, 175, 335, 109, 
#> 2.76, 3.21, 3.69, 3.92, 3.92, 3.92, 3.07, 3.07, 3.07, 2.93, 3, 
#> 3.23, 4.08, 4.93, 4.22, 3.7, 2.76, 3.15, 3.73, 3.08, 4.08, 4.43, 
#> 3.77, 4.22, 3.62, 3.54, 4.11, 3.46, 3.57, 3.19, 3.15, 3.44, 3.44, 
#> 4.07, 3.73, 3.78, 5.25, 5.424, 5.345, 2.2, 1.615, 1.835, 2.465, 
#> 3.52, 3.435, 3.84, 3.845, 1.935, 2.14, 1.513, 3.17, 2.77, 3.57, 
#> 2.78, 20.22, 15.84, 20, 22.9, 18.3, 18.9, 17.4, 17.6, 18, 17.98, 
#> 17.82, 17.42, 19.47, 18.52, 19.9, 20.01, 16.87, 17.3, 15.41, 
#> 17.05, 18.9, 16.7, 16.9, 14.5, 15.5, 14.6, 18.6, 1, 0, 1, 1, 
#> 1, 1, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 0, 0, 0, 0, 1, 0, 1, 0, 0, 
#> 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 
#> 0, 1, 1, 1, 1, 1, 1, 1, 3, 3, 4, 4, 4, 4, 3, 3, 3, 3, 3, 3, 4, 
#> 4, 4, 3, 3, 3, 3, 3, 4, 5, 5, 5, 5, 5, 4, 1, 4, 2, 2, 4, 4, 3, 
#> 3, 3, 4, 4, 4, 1, 2, 1, 1, 2, 2, 4, 2, 1, 2, 2, 4, 6, 8, 2, 0, 
#> 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 0, 0, 0, 0, 1, 1, 
#> 1, 0, 1, 0, 1, 1, 1, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 
#> 1, 1, 1, 1, 0, 0, 0, 1, 0, 1, 0, 1, 0, 1, 1, 1, 1, 0, 0, 0, 0, 
#> 0, 0, 1, 1, 1, 1, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 1, 0, 1, 0, 0, 
#> 0, 0, 1, 1, 1, 0, 0, 1, 0, 0, 0, 0, 1, 1, 1, 1, 0, 0, 0, 1, 1, 
#> 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 
#> 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 
#> 1, 1, 0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 
#> 1, 1, 0, 0, 1, 0, 0, 0, 1, 1, 1, 1, 1, 0, 0, 0, 1, 1, 1, 1, 1, 
#> 0, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 1, 0, 0, 
#> 0, 0, 1, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 
#> 0, 0, 1, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
#> 0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 1, 0, 1, 1, 
#> 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 1, 0, 1, 0, 0, 1, 
#> 0, 1), y = c(18.1, 14.3, 24.4, 22.8, 19.2, 17.8, 16.4, 17.3, 
#> 15.2, 10.4, 10.4, 14.7, 32.4, 30.4, 33.9, 21.5, 15.5, 15.2, 13.3, 
#> 19.2, 27.3, 26, 30.4, 15.8, 19.7, 15, 21.4), type.measure = "deviance", 
#>     nfolds = 5, family = "gaussian", alpha = 1)
```

<sup>Created on 2019-12-03 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

Would you be interested in some other changes too? For example, we could add a CI service to automate testing. There's also some things that I would suggest for the `predict()` methods when a classification model is created too. 

