### PR TITLE
Release 0.2.1

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -6,3 +6,4 @@
 ^docs$
 ^codecov\.yml$
 ^\.github$
+^CRAN-RELEASE$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: xrf
 Title: eXtreme RuleFit
-Version: 0.2.0
+Version: 0.2.1
 Authors@R: person("Karl", "Holub", email = "karljholub@gmail.com", role = c("aut", "cre"))
 Description: An implementation of the RuleFit algorithm as described in Friedman & Popescu 
   (2008) <doi:10.1214/07-AOAS148>. eXtreme Gradient Boosting ('XGBoost') is used 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,7 +15,7 @@ Depends: R (>= 3.1.0)
 License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.1.0
+RoxygenNote: 7.1.1
 Imports: 
     Matrix,
     glmnet (>= 3.0),

--- a/R/xrf.R
+++ b/R/xrf.R
@@ -86,7 +86,7 @@ xrf_preconditions <- function(family, xgb_control, glm_control,
 ## this may be exposed to the user in the future
 get_xgboost_objective <- function(family) {
   if (family == 'gaussian') {
-    return('reg:linear')
+    return('reg:squarederror')
   }
   else if (family == 'binomial') {
     return('binary:logistic')
@@ -395,13 +395,17 @@ xrf.formula <- function(object, data, family,
   model_matrix_method <- if (sparse) sparse.model.matrix else model.matrix
   design_matrix <- model_matrix_method(expanded_formula, data)
 
+  nrounds <- xgb_control$nrounds
+  # necessary to remove from params to avoid false positive warnings
+  xgb_control <- within(xgb_control, rm(nrounds))
+
   if (is.null(prefit_xgb)) {
     m_xgb <- xgboost(data = design_matrix,
-                     label = data[[response_var]],
-                     nrounds = xgb_control$nrounds,
-                     objective = get_xgboost_objective(family),
-                     params = xgb_control,
-                     verbose = 0)
+                   label = data[[response_var]],
+                   nround = nrounds,
+                   objective = get_xgboost_objective(family),
+                   params = xgb_control,
+                   verbose = 0)
     rules <- extract_xgb_rules(m_xgb)
   }
   else {

--- a/R/xrf.R
+++ b/R/xrf.R
@@ -402,7 +402,7 @@ xrf.formula <- function(object, data, family,
   if (is.null(prefit_xgb)) {
     m_xgb <- xgboost(data = design_matrix,
                    label = data[[response_var]],
-                   nround = nrounds,
+                   nrounds = nrounds,
                    objective = get_xgboost_objective(family),
                    params = xgb_control,
                    verbose = 0)

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,16 +1,19 @@
-## Resubmission
-This is an update of `xrf` from 0.1.2 to 0.2.0. Notable changes:
+## Submission
+This is a patch of `xrf` from 0.2.0 to 0.2.1. Changes:
 
-* shrunk the size of model objects by stripping call data
-* improved printing for large model formulas
-* `dplyr` 1.0 compatibility updates
+* Cleared xgboost unused parameters warning
+* Replaced use of deprecated xgboost objective function
 
 ## Test environments
 
-* macOS Mojave, R 4.0.0
-* Ubuntu Linux, R-release (https://builder.r-hub.io/status/xrf_0.2.0.tar.gz-fb376c63f80b4c1eb1b3847d7b5efb90)
-* Fedora Linux, R-devel (https://builder.r-hub.io/status/xrf_0.2.0.tar.gz-81cae60013dc4fa8a1d21902a6d34b10)
-* Windows, R-devel (via win-builder)
+* macOS Catalina, R-release
+* Debian Linux, R-devel (https://builder.r-hub.io/status/xrf_0.2.1.tar.gz-9af3f255b2c706689b5ce8a9df3eea24)
+* Windows, R-release (https://win-builder.r-project.org/94M9t7445SVe/00check.log)
 
 ## R CMD check results
 There were no ERRORs or WARNINGs on all platforms.
+
+win-builder contained NOTEs on example code runtime & an HTTP 500 in DOI lookup, which appear environment-specific.
+
+## Reverse Dependencies
+Were tested on macOS Catalina using `tools::check_packages_in_dir`; no ERRORs or WARNINGs were found.

--- a/tests/testthat/test_model.R
+++ b/tests/testthat/test_model.R
@@ -106,3 +106,15 @@ test_that('call scrubbed', {
   expect_true(object.size(mod_nsp$glm$model$call) < 211544)
 })
 
+
+test_that('single feature model', {
+  set.seed(55414)
+  x1 <- rbinom(100, 1, .7)
+  y <- rnorm(100, 0, .5) + x1
+  dat <- data.frame(y, x1)
+  mod <- xrf(y ~ x1, data = dat,
+                 xgb_control = list(nrounds = 5, max_depth = 2),
+                 family = "gaussian", sparse = FALSE)
+  expect_gt(nrow(mod$rules), 0)
+})
+


### PR DESCRIPTION
Resolves: #19 #16

Updates:

- New objective function for xgboost to clear deprecation warning
- Remove unused `nrounds` from `params` passed to xgboost