### PR TITLE
quiet name repair `colnames` message

### DIFF
--- a/R/xrf.R
+++ b/R/xrf.R
@@ -268,7 +268,7 @@ evaluate_rules <- function(rules, data) {
       as.integer() %>%
       data.frame()
     )
-  rule_features <- bind_cols(per_rule_evaluation$rule_evaluation)
+  rule_features <- bind_cols(per_rule_evaluation$rule_evaluation, .name_repair = "minimal")
   colnames(rule_features) <- per_rule_evaluation$rule_id
 
   rule_features
@@ -291,7 +291,7 @@ evaluate_rules_dense_only <- function(rules, data) {
         as.integer() %>%
         data.frame()
     )
-  rule_features <- bind_cols(per_rule_evaluation$rule_evaluation)
+  rule_features <- bind_cols(per_rule_evaluation$rule_evaluation, .name_repair = "minimal")
   colnames(rule_features) <- per_rule_evaluation$rule_id
 
   rule_features


### PR DESCRIPTION
Thanks again for your work on this package!

A small PR to quiet some dplyr messages about column name repair.

Previously:

``` r
data("ames", package = "modeldata")

xrf::xrf(
  Sale_Price ~ Neighborhood + Gr_Liv_Area + Central_Air,
  data = ames,
  family = "gaussian",
  xgb_control = list(nrounds = 3, max_depth = 3),
  verbose = 0
)
#> New names:
#> • `.` -> `....1`
#> • `.` -> `....2`
#> • `.` -> `....3`
#> • `.` -> `....4`
#> • `.` -> `....5`
#> • `.` -> `....6`
#> • `.` -> `....7`
#> • `.` -> `....8`
#> • `.` -> `....9`
#> • `.` -> `....10`
#> • `.` -> `....11`
#> • `.` -> `....12`
#> • `.` -> `....13`
#> • `.` -> `....14`
#> • `.` -> `....15`
#> • `.` -> `....16`
#> • `.` -> `....17`
#> • `.` -> `....18`
#> • `.` -> `....19`
#> • `.` -> `....20`
#> • `.` -> `....21`
#> • `.` -> `....22`
#> • `.` -> `....23`
#> • `.` -> `....24`
#> An eXtreme RuleFit model of 24 rules.
#> 
#> Original Formula:
#> 
#> Sale_Price ~ Neighborhood + Gr_Liv_Area + Central_Air
```

<sup>Created on 2022-06-05 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

Now:

``` r
data("ames", package = "modeldata")

xrf::xrf(
  Sale_Price ~ Neighborhood + Gr_Liv_Area + Central_Air,
  data = ames,
  family = "gaussian",
  xgb_control = list(nrounds = 3, max_depth = 3),
  verbose = 0
)
#> An eXtreme RuleFit model of 24 rules.
#> 
#> Original Formula:
#> 
#> Sale_Price ~ Neighborhood + Gr_Liv_Area + Central_Air
```

<sup>Created on 2022-06-05 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>
