### PR TITLE
quiet xgb warnings when prefit

### DIFF
--- a/R/xrf.R
+++ b/R/xrf.R
@@ -2,7 +2,7 @@
 ## functions for preconditions on user input
 #############################################
 
-condition_xgb_control <- function(family, xgb_control, data, response_var) {
+condition_xgb_control <- function(family, xgb_control, data, response_var, prefit_xgb) {
   # this is a duplicated but necessary check
   if (!(response_var %in% colnames(data))) {
     stop(paste0('Response variable "', response_var, '" not present in supplied data'))
@@ -10,7 +10,7 @@ condition_xgb_control <- function(family, xgb_control, data, response_var) {
 
   data_mutated <- data
 
-  if (family == 'multinomial' && is.null(xgb_control$num_class)) {
+  if (family == 'multinomial' && is.null(xgb_control$num_class) && is.null(prefit_xgb)) {
     n_classes <- n_distinct(data[[response_var]])
     warning(paste0('Detected ', as.character(n_classes), ' classes to set num_class xgb_control parameter'))
     xgb_control$num_class <- n_distinct(data[[response_var]])
@@ -61,7 +61,8 @@ xrf_preconditions <- function(family, xgb_control, glm_control,
   }
 
   if (family == 'multinomial' &&
-      (is.null(xgb_control$num_class) || n_distinct(data[[response_var]]) != xgb_control$num_class)) {
+      ((is.null(xgb_control$num_class) || n_distinct(data[[response_var]]) != xgb_control$num_class) &&
+      is.null(prefit_xgb))) {
     stop('Must supply a num_class list element in xgb_control when using multinomial objective')
   }
 
@@ -387,7 +388,7 @@ xrf.formula <- function(object, data, family,
   expanded_formula <- expand_formula(object, data)
   response_var <- get_response(expanded_formula)
 
-  xgboost_conditioned <- condition_xgb_control(family, xgb_control, data, response_var)
+  xgboost_conditioned <- condition_xgb_control(family, xgb_control, data, response_var, prefit_xgb)
   xgb_control <- xgboost_conditioned$xgb_control
   data <- xgboost_conditioned$data
   xrf_preconditions(family, xgb_control, glm_control, data, response_var, prefit_xgb)


### PR DESCRIPTION
A small PR to quiet warnings/errors from `xrf.formula` about the `xgb_control` object when passed a `prefit_xgb` object. Very much appreciating the prefitting option in xrf—allows us tidymodels folks to reuse a lot of machinery for training xgb models.👍

``` r
library(xrf)
library(rules) 
#> Loading required package: parsnip
data("ames", package = "modeldata")

# prefit an xgb object
xgb_fit <- 
  xgb_train(
    x = ames[,c("Lot_Area", "Year_Built")],
    y = ames[["Exter_Cond"]]
  )

xrf(
  Exter_Cond ~ Lot_Area + Year_Built,
  data = ames,
  family = "multinomial",
  prefit_xgb = xgb_fit
)
#> [edit: truncating output for brevity]
#> Warning in condition_xgb_control(family, xgb_control, data, response_var):
#> Detected 5 classes to set num_class xgb_control parameter
```

<sup>Created on 2022-06-05 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>