### PR TITLE
address incompatible types row binding error

### DIFF
--- a/R/xrf.R
+++ b/R/xrf.R
@@ -155,9 +155,18 @@ extract_xgb_rules <- function(m) {
     do(harvested_rules = rule_traverse(.data[1, ], .data) %>%
          filter(!is.na(.data$feature))) %>%
     pull(.data$harvested_rules) %>%
+    lapply(drop_zero_row_tbl) %>%
     bind_rows()
 
   rules
+}
+
+drop_zero_row_tbl <- function(tbl) {
+  if (nrow(tbl) == 0) {
+    return(NULL)
+  }
+
+  tbl
 }
 
 


### PR DESCRIPTION
Closes #18.

It looks like this error came up when some entries from the mapped `rule_traverse` list have zero rows and tibble assumes a `logical` type for each column. This PR avoids introducing a purrr dependency a la the solution proposed in the original issue by applying over a short function that drops 0-row tibbles before binding rows.

Re-running the failing reprex from the original issue with the xrf version from this branch:

``` r
data("ames", package = "modeldata")
ames$Sale_Price <- log10(ames$Sale_Price)

xrf::xrf(
  Sale_Price ~ Neighborhood + Longitude + Latitude +
    Gr_Liv_Area + Central_Air,
  data = ames,
  family = "gaussian",
  xgb_control = list(nrounds = 5, colsample_bynode = 1, 
                     colsample_bytree = 1/5),
  verbose = 0
)
#> An eXtreme RuleFit model of 10 rules.
#> 
#> Original Formula:
#> 
#> Sale_Price ~ Neighborhood + Longitude + Latitude + Gr_Liv_Area + Central_Air
```

<sup>Created on 2022-06-05 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

Much appreciated!