### PR TITLE
prep v0.2.2 release candidate

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -25,50 +25,19 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: r-lib/actions/setup-r@master
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
+          http-user-agent: ${{ matrix.config.http-user-agent }}
+          use-public-rspm: true
 
-      - uses: r-lib/actions/setup-pandoc@master
-
-      - name: Query dependencies
-        run: |
-          install.packages('remotes')
-          saveRDS(remotes::dev_package_deps(dependencies = TRUE), ".github/depends.Rds", version = 2)
-        shell: Rscript {0}
-
-      - name: Cache R packages
-        if: runner.os != 'Windows'
-        uses: actions/cache@v1
+      - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          path: ${{ env.R_LIBS_USER }}
-          key: ${{ runner.os }}-r-${{ matrix.config.r }}-${{ hashFiles('.github/depends.Rds') }}
-          restore-keys: ${{ runner.os }}-r-${{ matrix.config.r }}-
+          extra-packages: any::rcmdcheck
+          needs: check
 
-      - name: Install system dependencies
-        if: runner.os == 'Linux'
-        env:
-          RHUB_PLATFORM: linux-x86_64-ubuntu-gcc
-        run: |
-          Rscript -e "remotes::install_github('r-hub/sysreqs')"
-          sysreqs=$(Rscript -e "cat(sysreqs::sysreq_commands('DESCRIPTION'))")
-          sudo -s eval "$sysreqs"
-
-      - name: Install dependencies
-        run: |
-          remotes::install_deps(dependencies = TRUE)
-          remotes::install_cran("rcmdcheck")
-        shell: Rscript {0}
-
-      - name: Check
-        env:
-          _R_CHECK_CRAN_INCOMING_REMOTE_: false
-        run: rcmdcheck::rcmdcheck(args = c("--no-manual", "--as-cran"), error_on = "warning", check_dir = "check")
-        shell: Rscript {0}
-
-      - name: Upload check results
-        if: failure()
-        uses: actions/upload-artifact@master
+      - uses: r-lib/actions/check-r-package@v2
         with:
-          name: ${{ runner.os }}-r${{ matrix.config.r }}-results
-          path: check
+          upload-snapshots: true

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -12,11 +12,12 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: windows-latest, r: '3.6'}
-          - {os: macOS-latest, r: '3.6'}
-          - {os: macOS-latest, r: 'devel'}
-          - {os: ubuntu-16.04, r: '3.6', rspm: "https://demo.rstudiopm.com/all/__linux__/xenial/latest"}
-
+          - {os: macOS-latest,   r: 'release'}
+          - {os: windows-latest, r: 'release'}
+          - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
+          - {os: ubuntu-latest,   r: 'release'}
+          - {os: ubuntu-latest,   r: 'oldrel-1'}
+          - {os: ubuntu-latest,   r: 'oldrel-2'}
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
       RSPM: ${{ matrix.config.rspm }}

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: xrf
 Title: eXtreme RuleFit
-Version: 0.2.1
+Version: 0.2.2
 Authors@R: person("Karl", "Holub", email = "karljholub@gmail.com", role = c("aut", "cre"))
 Description: An implementation of the RuleFit algorithm as described in Friedman & Popescu 
   (2008) <doi:10.1214/07-AOAS148>. eXtreme Gradient Boosting ('XGBoost') is used 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,19 +1,13 @@
-## Submission
-This is a patch of `xrf` from 0.2.0 to 0.2.1. Changes:
-
-* Cleared xgboost unused parameters warning
-* Replaced use of deprecated xgboost objective function
-
 ## Test environments
 
-* macOS Catalina, R-release
-* Debian Linux, R-devel (https://builder.r-hub.io/status/xrf_0.2.1.tar.gz-9af3f255b2c706689b5ce8a9df3eea24)
-* Windows, R-release (https://win-builder.r-project.org/94M9t7445SVe/00check.log)
+* macOS, R-release (via GitHub Actions)
+* Ubuntu Linux, R-devel, release, oldrel-1, and oldrel-2 (via GitHub Actions)
+* Windows, R-devel (via win-builder) and R-release (via GitHub Actions)
 
 ## R CMD check results
-There were no ERRORs or WARNINGs on all platforms.
 
-win-builder contained NOTEs on example code runtime & an HTTP 500 in DOI lookup, which appear environment-specific.
+There were no ERRORs, WARNINGs, or NOTEs on all platforms.
 
 ## Reverse Dependencies
-Were tested on macOS Catalina using `tools::check_packages_in_dir`; no ERRORs or WARNINGs were found.
+
+This package has one CRAN dependency, `rules`. Comparing R CMD check results across CRAN and dev versions of this package, we saw no new problems.


### PR DESCRIPTION
Hey there, @holub008! I had a moment this morning and thought I'd put together a quick release candidate for a new CRAN release of the package. I've tested this locally and on win-builder, ran reverse dependency checks, and updated the GHA build systems to hopefully address the [minimum-R-version installation failures](https://github.com/holub008/xrf/actions/runs/3025349150/jobs/4867715738) you were seeing with 3.6 on `master`. This PR:

* bumps version to v0.2.2
* makes cran comments more minimal, as we tend to leave them as-is unless we anticipate the submission not to be auto-processed
* updates Actions build systems to automatically bump versions as new releases of R and operating systems come out

Glad to pass along more detailed revdepcheck results or win-builder check results, if appreciated.

Hope this is helpful for you, and let me know if I can lend a hand otherwise in getting these recent changes shipped out!